### PR TITLE
Improve logging and docs for server

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,11 @@
+# Olotext Server
+
+This directory contains the Fastify server powering the demo game. Use `npm run dev` to start it during development.
+
+## Logging
+
+The server uses Fastify's built-in logger. Additional logs have been added so that calls to `/play` and errors are visible in the console. When the `OPENAI_API_KEY` environment variable is present the server will also attempt to fetch narration from OpenAI; any failures are logged.
+
+## Error handling
+
+Unhandled exceptions are caught by a global error handler which returns a generic 500 response while logging the underlying error.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,15 +2,26 @@ import Fastify from 'fastify';
 import cors from '@fastify/cors';
 import { applyAgents, initialState } from './game/engine.js';
 
+/**
+ * Creates and configures the Fastify server used by the demo.
+ */
+
 export const createServer = () => {
   const fastify = Fastify({ logger: true });
   const state = initialState();
 
   fastify.register(cors, { origin: true });
 
+  // Centralised error handling so that uncaught exceptions are logged
+  fastify.setErrorHandler((error, request, reply) => {
+    fastify.log.error({ err: error }, 'Unhandled error');
+    reply.status(500).send({ error: 'Internal Server Error' });
+  });
+
   fastify.post('/play', async (request, reply) => {
     const body = request.body as { option?: string } | undefined;
-    const result = await applyAgents(state, body?.option);
+    fastify.log.info({ option: body?.option }, 'processing /play');
+    const result = await applyAgents(state, body?.option, fastify.log);
     reply.send(result);
   });
 
@@ -20,6 +31,7 @@ export const createServer = () => {
 if (process.env.NODE_ENV !== 'test') {
   const fastify = createServer();
   fastify.listen({ port: 3000 }).then(() => {
+    // eslint-disable-next-line no-console -- provide a visible hint when running manually
     console.log('🚀 Server ready at http://localhost:3000');
   });
 }


### PR DESCRIPTION
## Summary
- add a server README explaining logging and error handling
- add comments and logging facilities in the game engine
- log `/play` requests and add a global error handler

## Testing
- `npm test` in `server`
- `npm test` in `client`
- `npm run dev` in `server`

------
https://chatgpt.com/codex/tasks/task_e_687379ff99a08329b50ce1510176c954