### PR TITLE
Show option narrative immediately

### DIFF
--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -7,7 +7,10 @@ vi.mock('./api');
 
 (api.fetchNarrative as vi.Mock).mockResolvedValue({
   narrative: 'Hello world',
-  options: ['opt1', 'opt2'],
+  options: [
+    { optionKey: '1', content: 'opt1', narrative: 'n1' },
+    { optionKey: '2', content: 'opt2', narrative: 'n2' },
+  ],
 });
 
 describe('App', () => {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,17 +1,23 @@
 import { useState, useEffect } from 'react';
-import { fetchNarrative } from './api';
+import { fetchNarrative, NarrativeOption } from './api';
 
 export default function App() {
   const [narrative, setNarrative] = useState('');
-  const [options, setOptions] = useState<any[]>([]);
+  const [options, setOptions] = useState<NarrativeOption[]>([]);
   const [loading, setLoading] = useState(false);
 
-  const load = async (option?: any) => {
+  const load = async (optionKey?: string) => {
     setLoading(true);
-    const res = await fetchNarrative(option?.optionKey);
+    const res = await fetchNarrative(optionKey);
     setNarrative(res.narrative);
     setOptions(res.options);
     setLoading(false);
+  };
+
+  const handleOption = (o: NarrativeOption) => {
+    setNarrative(o.narrative);
+    setOptions([]);
+    load(o.optionKey);
   };
 
   useEffect(() => {
@@ -26,7 +32,7 @@ export default function App() {
       <ul>
         {options.map((o, i) => (
           <li key={i}>
-            <button onClick={() => load(o)}>{o.content}</button>
+            <button onClick={() => handleOption(o)}>{o.content}</button>
           </li>
         ))} 
       </ul>

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1,6 +1,12 @@
+export interface NarrativeOption {
+  optionKey: string;
+  content: string;
+  narrative: string;
+}
+
 export interface PlayResult {
   narrative: string;
-  options: string[];
+  options: NarrativeOption[];
 }
 
 export const fetchNarrative = async (option?: string): Promise<PlayResult> => {

--- a/server/src/engine.test.ts
+++ b/server/src/engine.test.ts
@@ -11,7 +11,7 @@ describe('engine', () => {
 
   it('advances scene when option chosen', async () => {
     const state = initialState();
-    await applyAgents(state, 'Examine the brass key on the side table.');
+    await applyAgents(state, 'examine_brass_key');
     const res = await applyAgents(state);
     expect(res.narrative).not.toEqual('');
   });

--- a/server/src/index.test.ts
+++ b/server/src/index.test.ts
@@ -12,5 +12,6 @@ describe('server', () => {
     const body = res.json();
     expect(body.narrative).toContain('Elric Manor');
     expect(body.options.length).toBeGreaterThan(0);
+    expect(body.options[0]).toHaveProperty('narrative');
   });
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -37,7 +37,11 @@ export const createServer = () => {
     state = result;
     const answer = {
       narrative: result.narrative,
-      options: result.options.map((o) => ({ optionKey: o.optionKey, content: o.option })),
+      options: result.options.map((o) => ({
+        optionKey: o.optionKey,
+        content: o.option,
+        narrative: o.narrative,
+      })),
     };
     reply.send(answer);
   });


### PR DESCRIPTION
## Summary
- return option narratives from the API
- update server tests for new response shape
- include option narratives in client API types
- show the chosen option narrative immediately on click
- adjust client tests and engine tests for option keys

## Testing
- `cd server && npm install && npm test`
- `cd ../client && npm install && npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a94eb6d4883298200eecacbfdb769